### PR TITLE
Fixing incorrect text color in scrutiny theme

### DIFF
--- a/src/pages/login.tsx
+++ b/src/pages/login.tsx
@@ -33,7 +33,7 @@ export default function login() {
 
     return (
         <div className="items-center h-screen w-screen justify-center flex flex-col">
-            <div className="text-center items-center justify-center flex flex-col gap-2">
+            <div className="text-center items-center justify-center flex flex-col gap-2 dark:text-WHITE_PRINCIPAL">
                 <ReadCvLogo size={64} className="text-PRINCIPAL" />
                 <p className="text-xl">Bem vindo ao </p>
                 <span className="text-4xl font-semibold">Weekly Report</span>
@@ -49,7 +49,9 @@ export default function login() {
                             bg-none
                             text-GRAY_DARK
                             border-PRINCIPAL
-                            hover:bg-PRINCIPAL hover:text-WHITE_PRINCIPAL"
+                            hover:bg-PRINCIPAL hover:text-WHITE_PRINCIPAL
+                             dark:text-WHITE_PRINCIPAL
+                            "
                             onClick={handleLogin}
                         >
                             <GoogleLogo size={24} />

--- a/src/pages/report/[id].tsx
+++ b/src/pages/report/[id].tsx
@@ -320,8 +320,8 @@ export default function EditReport() {
                                                     icone "<Plus />"
                                                 </p>
                                             ) : (
-                                                <p>
-                                                    Sem metas de <i>check</i>
+                                                <p className="flex text-LIGHT_TEXT_SECONDARY dark:text-DARK_TEXT">
+                                                    Sem metas de <i className="pl-2"> check</i>
                                                 </p>
                                             )}
                                         </div>


### PR DESCRIPTION
Na tela de reports corrigi a visualização do texto que não alterar a cor ao trocar para modo escuro, na tela de login, o botão e o texto acima dele não estavam alterando suas cores ao alterar o tema, então ajustei as cores para melhor visualização dos usuários.